### PR TITLE
Pages inhalt aktualisierung

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, cursor/pages-inhalt-aktualisierung-c379]
   workflow_dispatch:
 
 permissions:
@@ -28,3 +28,12 @@ jobs:
           path: .
       - uses: actions/deploy-pages@v4
         id: deployment
+      - name: Deployment-Link ausgeben
+        run: |
+          echo ""
+          echo "=============================================="
+          echo "✅ GitHub Pages erfolgreich deployed!"
+          echo "=============================================="
+          echo "🌐 Deine Seite ist live unter:"
+          echo "   https://yairosmapono.github.io/Yairos.github.io/"
+          echo "=============================================="


### PR DESCRIPTION
Add deployment trigger for feature branch and output GitHub Pages URL in logs.

The previous workflow only deployed from the `main` branch, preventing updates from the `cursor/pages-inhalt-aktualisierung-c379` feature branch from appearing on GitHub Pages.

---
<p><a href="https://cursor.com/agents/bc-9eea9b3c-c7f7-45fe-8069-f14e50d26ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eea9b3c-c7f7-45fe-8069-f14e50d26ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

